### PR TITLE
add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ build/nodejs-lib-ruby-parser.js
 
 # gh pages
 gh-pages/lib-ruby-parser.js
+
+# benchmark assets
+benchmark/repos
+benchmark/filelist
+benchmark/repos.zip
+benchmark/ruby-parser.rb
+benchmark/rust-parser
+benchmark/stats

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include codegen/build.mk
 include build/build.mk
 include tests/build.mk
 include gh-pages/build.mk
+include benchmark/build.mk
 
 clean:
 	rm -rf $(CLEAN)

--- a/benchmark/build.mk
+++ b/benchmark/build.mk
@@ -1,0 +1,47 @@
+define download_latest_bench_asset
+ASSET_NAME=$(1) SAVE_AS=$(2) ruby benchmark/download_asset.rb
+endef
+
+benchmark/download:
+	@echo "Downloading repos.zip..."
+	$(call download_latest_bench_asset,repos.zip,benchmark/repos.zip)
+	@echo "Unpacking repos.zip..."
+	unzip --help
+	ls -l benchmark/repos.zip
+	unzip -q benchmark/repos.zip -d benchmark
+
+	@echo "Downloading Rust parser..."
+	$(call download_latest_bench_asset,$(BENCHMARK_RUNNER_ASSET_NAME),benchmark/rust-parser)
+	chmod +x benchmark/rust-parser
+
+	@echo "Downloading Ruby parser..."
+	$(call download_latest_bench_asset,ruby-parser.rb,benchmark/ruby-parser.rb)
+
+BENCHMARK_ASSETS = \
+	benchmark/repos \
+	benchmark/filelist \
+	benchmark/repos.zip \
+	benchmark/ruby-parser.rb \
+	benchmark/rust-parser \
+	benchmark/stats
+
+benchmark/clear:
+	rm -rf $(BENCHMARK_ASSETS)
+
+define run_benchmark
+cd benchmark && FILELIST_PATH=filelist $(1)
+endef
+
+benchmark/compare:
+	$(call run_benchmark, ./rust-parser)
+	$(call run_benchmark, ruby ruby-parser.rb)
+	$(call run_benchmark, NODE_DISABLE_COLORS=1 node node-wasm-parser.js)
+
+BENCHMARK_RECORDING = $(TARGET).benchmark-out
+benchmark/record:
+	echo "Rust:" > $(BENCHMARK_RECORDING)
+	$(call run_benchmark, ./rust-parser >> ../$(BENCHMARK_RECORDING))
+	echo "Ruby:" >> $(BENCHMARK_RECORDING)
+	$(call run_benchmark, ruby ruby-parser.rb >> ../$(BENCHMARK_RECORDING))
+	echo "WASM (Node.js):" >> $(BENCHMARK_RECORDING)
+	$(call run_benchmark, NODE_DISABLE_COLORS=1 node node-wasm-parser.js >> ../$(BENCHMARK_RECORDING))

--- a/benchmark/download_asset.rb
+++ b/benchmark/download_asset.rb
@@ -1,0 +1,17 @@
+require 'open-uri'
+require 'json'
+
+def abort(message)
+    $stderr.puts("Error: #{message}\n\nAborting.")
+    exit(1)
+end
+
+asset_name = ENV.fetch('ASSET_NAME') { abort 'ASSET_NAME env var must be provided.' }
+asset_url = "https://github.com/lib-ruby-parser/bench/releases/download/v0.0.1/#{asset_name}"
+save_as = ENV.fetch('SAVE_AS') { abort 'SAVE_AS env var must be provided' }
+
+File.open(save_as, 'wb') do |file|
+    URI.open(asset_url, 'rb') do |asset|
+        file.write(asset.read)
+    end
+end

--- a/benchmark/node-wasm-parser.js
+++ b/benchmark/node-wasm-parser.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const LibRubyParser = require('../build/nodejs-lib-ruby-parser.js');
+
+const filelist = fs.readFileSync(process.env.FILELIST_PATH).toString().split("\n");
+const files = filelist.map(filepath => fs.readFileSync(filepath).toString());
+
+const start = performance.now();
+
+for (let file of files) {
+    LibRubyParser.parse(file);
+}
+
+const end = performance.now();
+console.log((end - start) / 1000);

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 js-sys = "0.3.55"
-lib-ruby-parser = {version = "3.0.12", features = ["debug-all"]}
+lib-ruby-parser = {version = "3.0.12"}
 wasm-bindgen = "0.2.63"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
@@ -33,4 +33,5 @@ wasm-bindgen-test = "0.3.13"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.
+lto = true
 opt-level = "s"

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -352,6 +352,7 @@ pub fn parse(
     buffer_name: Option<String>,
     decoder: js_sys::Function,
 ) -> JsParserResult {
+    // let start = lib_ruby_parser__now();
     let options = RustParserOptions {
         buffer_name: buffer_name.unwrap_or_else(|| String::from("(eval)")),
         decoder: fn_based_decoder(decoder),
@@ -360,6 +361,18 @@ pub fn parse(
     };
     let parser = RustParser::new(input, options);
     let output = parser.do_parse();
+    // let end = lib_ruby_parser__now();
+    // log(&format!("Parsing took {:.10}", end - start));
 
-    output.into_js()
+    // let start = lib_ruby_parser__now();
+    let output = output.into_js();
+    // let end = lib_ruby_parser__now();
+    // log(&format!("Conversion took {:.10}", end - start));
+
+    output
+}
+
+#[wasm_bindgen]
+extern "C" {
+    fn lib_ruby_parser__now() -> f64;
 }

--- a/build/build.mk
+++ b/build/build.mk
@@ -23,7 +23,7 @@ endif
 $(info TARGET = $(TARGET))
 
 RUN_WASM_PACK = cd bindings && \
-	wasm-pack build --target $(TARGET) && \
+	wasm-pack build --release --target $(TARGET) && \
 	cd .. && \
 	cp bindings/pkg/lib_ruby_parser_wasm.js build/$(ENV)-lib-ruby-parser-wrapper.js && \
 	cp bindings/pkg/lib_ruby_parser_wasm_bg.wasm build/$(ENV)-lib-ruby-parser.wasm

--- a/js/types.js
+++ b/js/types.js
@@ -85,3 +85,7 @@ root.MagicComment = MagicComment;
 root.DecodedInput = DecodedInput;
 root.SourceLine = SourceLine;
 root.ParserResult = ParserResult;
+
+function lib_ruby_parser__now() {
+    return performance.now();
+}


### PR DESCRIPTION
current results:
```
$ make benchmark/compare
TARGET = no-modules
cd benchmark && FILELIST_PATH=filelist  ./rust-parser
1.6806495760
cd benchmark && FILELIST_PATH=filelist  ruby ruby-parser.rb
4.902745999977924
cd benchmark && FILELIST_PATH=filelist  NODE_DISABLE_COLORS=1 node node-wasm-parser.js
9.411326888918877
```

From what I see calling JS functions is too expensive, so I'll try to use (and expose) WASM classes instead of JS equivalents.